### PR TITLE
remove null from favorite className output

### DIFF
--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -20,7 +20,7 @@ interface ICardProps {
 
 export const Card: React.FC<ICardProps> = (props) => {
   const [favs, setFavs] = useState(JSON.parse(localStorage.items || '{}'));
-  const favClass = (favs[props.url]) ? 'active' : null;
+  const favClass = (favs[props.url]) ? 'active' : '';
 
   const handleClick = (data: any) => {
 


### PR DESCRIPTION
Inspect Luke Skywalker when he's not a favorite and it outputs null as a class, this changes it over to an empty string instead.

We are working together again! 